### PR TITLE
Simplify clock.toString

### DIFF
--- a/src/main/scala/Clock.scala
+++ b/src/main/scala/Clock.scala
@@ -271,15 +271,11 @@ object Clock {
         case _  => limitFormatter.format(limitSeconds / 60d)
       }
 
-    def incrementString: String = if (hasIncrement) s"+${incrementSeconds}" else ""
-
-    def byoyomiString: String = if (hasByoyomi || !hasIncrement) s"|${byoyomiSeconds}" else ""
-
     def periodsString: String = if (periodsTotal > 1) s"(${periodsTotal}x)" else ""
 
-    def show = toString
+    def show: String = if (hasIncrement) s"${limitString}+${incrementSeconds}" else s"${limitString}|${byoyomiSeconds}${periodsString}"
 
-    override def toString = s"${limitString}${incrementString}${byoyomiString}${periodsString}"
+    override def toString = s"${limitSeconds}.${incrementSeconds}.${byoyomiSeconds}.${periodsTotal}"
   }
 
   def parseJPTime(str: String): Option[Int] = {

--- a/src/main/scala/Clock.scala
+++ b/src/main/scala/Clock.scala
@@ -271,9 +271,11 @@ object Clock {
         case _  => limitFormatter.format(limitSeconds / 60d)
       }
 
+    def baseString: String = if (hasIncrement) s"${limitSeconds}+${incrementSeconds}" else s"${limitSeconds}"
+
     def periodsString: String = if (periodsTotal > 1) s"(${periodsTotal}x)" else ""
 
-    def show: String = if (hasIncrement) s"${limitString}+${incrementSeconds}" else s"${limitString}|${byoyomiSeconds}${periodsString}"
+    def show: String = if (hasByoyomi) s"${baseString}|${byoyomiSeconds}${periodsString}" else baseString
 
     override def toString = s"${limitSeconds}.${incrementSeconds}.${byoyomiSeconds}.${periodsTotal}"
   }


### PR DESCRIPTION
Whether or not https://github.com/WandererXII/lishogi/pull/545 is accepted, I do not understand a need for Clock#toString to contain the pipe character which PlayFramework actors disallow.